### PR TITLE
Remove overly restrictive working-directory restrictions

### DIFF
--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -895,8 +895,7 @@
                   "working-directory": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun",
                     "description": "Using the working-directory keyword, you can specify the working directory of where to run the command.",
-                    "type": "string",
-                    "pattern": "^(\\.[^\\\\?%*:|\"<>\\n]+)$"
+                    "type": "string"
                   },
                   "shell": {
                     "$comment": "https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell",


### PR DESCRIPTION
There is no reason to limit the working directory like this. It's totally valid to reference `/tmp/foobar` for instance.

Fixes https://github.com/Lona/vscode-github-actions/issues/2