### PR TITLE
Update list of available runners

### DIFF
--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -781,11 +781,13 @@
                   "enum": [
                     "${{ matrix.os }}",
                     "macos-latest",
+                    "macos-10.15",
                     "self-hosted",
                     "ubuntu-16.04",
                     "ubuntu-18.04",
                     "ubuntu-latest",
-                    "windows-latest"
+                    "windows-latest",
+                    "windows-2019"
                   ]
                 },
                 {


### PR DESCRIPTION
This PR adds missing `windows-2019` and `macos-10.15` runners to the list.

Ref: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#github-hosted-runners.

Virtual environment | YAML workflow label
-- | --
Windows Server 2019 | `windows-latest` or `windows-2019`
Ubuntu 18.04 | `ubuntu-latest` or `ubuntu-18.04`
Ubuntu 16.04 | `ubuntu-16.04`
macOS Catalina 10.15 | `macos-latest` or `macos-10.15`

